### PR TITLE
[fix] use Persistence volume in addons Elasticsearch

### DIFF
--- a/root-kubernetes/addon-EFK/es-statefulset.yaml
+++ b/root-kubernetes/addon-EFK/es-statefulset.yaml
@@ -118,7 +118,7 @@ spec:
           name: transport
           protocol: TCP
         volumeMounts:
-        - name: elasticsearch-logging
+        - name: es-persistent-storage
           mountPath: /data
         env:
         - name: "NAMESPACE"


### PR DESCRIPTION
# What is this PR?
if we wanna use persistent volume in addons Elasticsearch, need to change volumeMounts `es-persistent-storage`.

`elasticsearch-logging` is ["emptyDir"](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)

